### PR TITLE
ECSとの衝突の回避、及び、起動時動作微修正

### DIFF
--- a/Assets/MainLoopProfiling/Scripts/CustomPlayerLoop.cs
+++ b/Assets/MainLoopProfiling/Scripts/CustomPlayerLoop.cs
@@ -57,8 +57,7 @@ namespace UTJ
         private static float firstPreCullingPoint = 0.0f;
 
 
-        [RuntimeInitializeOnLoadMethod]
-        static void Init()
+        public static void Init()
         {
             System.Type[] profilePoints = {
                 // script
@@ -80,6 +79,7 @@ namespace UTJ
             };
 
             var playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+
             AppendProfilingLoopSystem(ref playerLoop, profilePoints);
             PlayerLoop.SetPlayerLoop(playerLoop);
         }

--- a/Assets/MainLoopProfiling/Scripts/CustomPlayerLoop.cs
+++ b/Assets/MainLoopProfiling/Scripts/CustomPlayerLoop.cs
@@ -78,7 +78,11 @@ namespace UTJ
                 typeof( FixedUpdate.PhysicsFixedUpdate),
             };
 
+#if UNITY_2019_3_OR_NEWER
+            var playerLoop = PlayerLoop.GetCurrentPlayerLoop();
+#else
             var playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+#endif
 
             AppendProfilingLoopSystem(ref playerLoop, profilePoints);
             PlayerLoop.SetPlayerLoop(playerLoop);

--- a/Assets/MainLoopProfiling/Scripts/ProfilingUI.cs
+++ b/Assets/MainLoopProfiling/Scripts/ProfilingUI.cs
@@ -33,6 +33,13 @@ namespace UTJ
         private int sumCount = 0;
         private int currentStartSec = 0;
 
+        private void Awake()
+        {
+            if (Application.isPlaying)
+            {
+                CustomPlayerLoop.Init();
+            }
+        }
 
         private void Start()
         {


### PR DESCRIPTION
ECSと同時使用ができない問題を修正しました。ただしこれが有効になるのはUnity 2019.3以降のみとなります。
また、本機能を使わない時にはPlayerLoopを変更しないように修正しました。